### PR TITLE
Fix Electronica schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,9 +40,9 @@
     </tr>
     <tr><td>13:15–14:45</td><td class="ingles">Inglés II<br>Aula 203 (3R1)</td><td></td><td></td><td></td><td></td></tr>
     <tr><td>15:40–18:05</td><td></td><td></td><td class="asys">Análisis de Señales y Sistemas<br>Aula 205 (2R1)</td><td class="asys">Análisis de Señales y Sistemas<br>Aula 205 (2R1)</td><td></td></tr>
-    <tr><td>18:15–19:45</td><td></td><td class="dispo">Dispositivos Electrónicos<br>Lab Anexo<br>Prof. Sigampa</td><td></td><td></td><td class="seguridad">Seguridad e Higiene<br>Aula 604 (4R2)</td></tr>
-    <tr><td>19:55–20:40</td><td></td><td class="circuitos">Teoría de los Circuitos I<br>Aula 707 (3R3)<br>Prof. Peluca</td><td></td><td class="aplicada">Electrónica Aplicada I<br>Aula 512 (3R2)<br>Prof. Rivas</td><td class="dispo">Dispositivos Electrónicos<br>Aula 209<br>Prof. Guanuco</td></tr>
-    <tr><td>20:40–21:25</td><td></td><td class="circuitos">Teoría de los Circuitos I<br>Aula 707 (3R3)<br>Prof. Peluca</td><td class="aplicada">Electrónica Aplicada I<br>Lab<br>Prof. Gilberto</td><td class="aplicada">Electrónica Aplicada I<br>Aula 512 (3R2)<br>Prof. Rivas</td><td class="dispo">Dispositivos Electrónicos<br>Aula 209<br>Prof. Guanuco</td></tr>
+    <tr><td>18:15–19:55</td><td></td><td class="dispo">Dispositivos Electrónicos<br>Lab Anexo<br>Prof. Sigampa</td><td></td><td class="aplicada">Electrónica Aplicada I<br>Aula 512 (3R2)<br>Prof. Rivas</td><td class="seguridad">Seguridad e Higiene<br>Aula 604 (4R2)</td></tr>
+    <tr><td>19:55–20:40</td><td></td><td class="circuitos">Teoría de los Circuitos I<br>Aula 707 (3R3)<br>Prof. Peluca</td><td></td><td></td><td class="dispo">Dispositivos Electrónicos<br>Aula 209<br>Prof. Guanuco</td></tr>
+    <tr><td>20:40–21:25</td><td></td><td class="circuitos">Teoría de los Circuitos I<br>Aula 707 (3R3)<br>Prof. Peluca</td><td class="aplicada">Electrónica Aplicada I<br>Lab<br>Prof. Gilberto</td><td></td><td class="dispo">Dispositivos Electrónicos<br>Aula 209<br>Prof. Guanuco</td></tr>
     <tr><td>21:25–23:05</td><td></td><td></td><td class="aplicada">Electrónica Aplicada I<br>Lab<br>Prof. Gilberto</td><td></td><td class="dispo">Dispositivos Electrónicos<br>Aula 209<br>Prof. Guanuco</td></tr>
   </table>
 
@@ -67,7 +67,7 @@ const horarioMaterias = [
   { dia: 3, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
   { dia: 3, hora: "20:40", materia: "Electrónica Aplicada I (Gilberto)" },
   { dia: 4, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
-  { dia: 4, hora: "19:55", materia: "Electrónica Aplicada I (Rivas)" },
+  { dia: 4, hora: "18:15", materia: "Electrónica Aplicada I (Rivas)" },
   { dia: 5, hora: "18:15", materia: "Seguridad e Higiene" },
   { dia: 5, hora: "20:40", materia: "Dispositivos Electrónicos (Guanuco)" }
 ];

--- a/recordatorio.html
+++ b/recordatorio.html
@@ -20,7 +20,7 @@
       { dia: 3, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
       { dia: 3, hora: "20:40", materia: "Electrónica Aplicada I (Gilberto)" },
       { dia: 4, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
-      { dia: 4, hora: "19:55", materia: "Electrónica Aplicada I (Rivas)" },
+      { dia: 4, hora: "18:15", materia: "Electrónica Aplicada I (Rivas)" },
       { dia: 5, hora: "18:15", materia: "Seguridad e Higiene" },
       { dia: 5, hora: "20:40", materia: "Dispositivos Electrónicos (Guanuco)" }
     ];


### PR DESCRIPTION
## Summary
- correct Thursday time slot for Electrónica Aplicada I
- adjust reminder arrays to start at 18:15 instead of 19:55

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_68546ecf528c8321a098546db23ca043