### PR TITLE
Fix document start

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-"""<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="es">
 <head>
   <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- remove stray triple quotes at the beginning of `index.html`

## Testing
- `grep -n '"""' -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_68547120b8748321911caa49eb64aa2e