### PR TITLE
Add docs about schedule edits and localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ Este sitio contiene:
 3. Activá GitHub Pages desde la pestaña **Settings > Pages**.
 4. ¡Listo! Visitá `https://tucuenta.github.io`.
 
+
+## Cómo editar el horario y las tareas
+
+El horario que ves en `index.html` se puede modificar abriendo ese archivo en un editor de texto y cambiando las celdas de la tabla. Allí podés agregar o quitar materias según tus necesidades.
+
+La sección **Objetivos y Entregas** guarda automáticamente cada cambio en `localStorage`. Esto significa que la lista de tareas se almacena en tu navegador y no en el servidor.
+
+> **Importante:** las tareas solo se conservan en el navegador que estés usando. Si abrís la página desde otro dispositivo o limpiás la caché, esos datos se perderán.


### PR DESCRIPTION
## Summary
- document how to edit the timetable in `index.html`
- explain that tasks are saved in `localStorage`
- warn that objectives are kept only in the browser

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685471369c248321a703a317212c132a