### PR TITLE
Reuse horario data across pages

### DIFF
--- a/horario.js
+++ b/horario.js
@@ -1,0 +1,11 @@
+const horario = [
+  { dia: 1, hora: "13:15", materia: "Inglés II" },
+  { dia: 2, hora: "18:15", materia: "Dispositivos Electrónicos (Sigampa)" },
+  { dia: 2, hora: "19:55", materia: "Teoría de los Circuitos I (Peluca)" },
+  { dia: 3, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
+  { dia: 3, hora: "20:40", materia: "Electrónica Aplicada I (Gilberto)" },
+  { dia: 4, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
+  { dia: 4, hora: "18:15", materia: "Electrónica Aplicada I (Rivas)" },
+  { dia: 5, hora: "18:15", materia: "Seguridad e Higiene" },
+  { dia: 5, hora: "20:40", materia: "Dispositivos Electrónicos (Guanuco)" }
+];

--- a/index.html
+++ b/index.html
@@ -58,19 +58,9 @@
   <br>
   <button onclick="agregarFila()">➕ Agregar nueva tarea</button>
 
+<script src="horario.js"></script>
 <script>
 // Recordatorio de materias
-const horarioMaterias = [
-  { dia: 1, hora: "13:15", materia: "Inglés II" },
-  { dia: 2, hora: "18:15", materia: "Dispositivos Electrónicos (Sigampa)" },
-  { dia: 2, hora: "19:55", materia: "Teoría de los Circuitos I (Peluca)" },
-  { dia: 3, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
-  { dia: 3, hora: "20:40", materia: "Electrónica Aplicada I (Gilberto)" },
-  { dia: 4, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
-  { dia: 4, hora: "18:15", materia: "Electrónica Aplicada I (Rivas)" },
-  { dia: 5, hora: "18:15", materia: "Seguridad e Higiene" },
-  { dia: 5, hora: "20:40", materia: "Dispositivos Electrónicos (Guanuco)" }
-];
 
 function mostrarRecordatorio() {
   const ahora = new Date();
@@ -82,7 +72,7 @@ function mostrarRecordatorio() {
   let mensaje = "No tenés clases dentro de una hora.";
   let siguienteClase = null;
 
-  for (const clase of horarioMaterias) {
+  for (const clase of horario) {
     if (clase.dia === diaSemana) {
       const [h, m] = clase.hora.split(":").map(Number);
       const totalMinClase = h * 60 + m;
@@ -96,7 +86,7 @@ function mostrarRecordatorio() {
 
   const ahoraTotalMin = diaSemana * 1440 + totalMinActual;
   let minDiferencia = Infinity;
-  for (const clase of horarioMaterias) {
+  for (const clase of horario) {
     const [h, m] = clase.hora.split(":").map(Number);
     const claseTotalMin = clase.dia * 1440 + (h * 60 + m);
     const diferencia = claseTotalMin - ahoraTotalMin;

--- a/recordatorio.html
+++ b/recordatorio.html
@@ -12,18 +12,8 @@
 <body>
   <h1>⏰ ¿Qué materia tengo pronto?</h1>
   <div id="mensaje">Calculando...</div>
+  <script src="horario.js"></script>
   <script>
-    const horario = [
-      { dia: 1, hora: "13:15", materia: "Inglés II" },
-      { dia: 2, hora: "18:15", materia: "Dispositivos Electrónicos (Sigampa)" },
-      { dia: 2, hora: "19:55", materia: "Teoría de los Circuitos I (Peluca)" },
-      { dia: 3, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
-      { dia: 3, hora: "20:40", materia: "Electrónica Aplicada I (Gilberto)" },
-      { dia: 4, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
-      { dia: 4, hora: "18:15", materia: "Electrónica Aplicada I (Rivas)" },
-      { dia: 5, hora: "18:15", materia: "Seguridad e Higiene" },
-      { dia: 5, hora: "20:40", materia: "Dispositivos Electrónicos (Guanuco)" }
-    ];
     function mostrarRecordatorio() {
       const ahora = new Date();
       const diaSemana = ahora.getDay();


### PR DESCRIPTION
## Summary
- pull duplicated schedule data into `horario.js`
- load `horario.js` from both HTML pages
- use the shared `horario` variable to show reminders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68547134a070832197e06e286856a224