### PR TITLE
Update schedule with Wednesday circuits class

### DIFF
--- a/horario.js
+++ b/horario.js
@@ -3,6 +3,7 @@ const horario = [
   { dia: 2, hora: "18:15", materia: "Dispositivos Electrónicos (Sigampa)" },
   { dia: 2, hora: "19:55", materia: "Teoría de los Circuitos I (Peluca)" },
   { dia: 3, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
+  { dia: 3, hora: "18:15", materia: "Teoría de los Circuitos I (Peluca)" },
   { dia: 3, hora: "20:40", materia: "Electrónica Aplicada I (Gilberto)" },
   { dia: 4, hora: "15:40", materia: "Análisis de Señales y Sistemas" },
   { dia: 4, hora: "18:15", materia: "Electrónica Aplicada I (Rivas)" },

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     </tr>
     <tr><td>13:15–14:45</td><td class="ingles">Inglés II<br>Aula 203 (3R1)</td><td></td><td></td><td></td><td></td></tr>
     <tr><td>15:40–18:05</td><td></td><td></td><td class="asys">Análisis de Señales y Sistemas<br>Aula 205 (2R1)</td><td class="asys">Análisis de Señales y Sistemas<br>Aula 205 (2R1)</td><td></td></tr>
-    <tr><td>18:15–19:55</td><td></td><td class="dispo">Dispositivos Electrónicos<br>Lab Anexo<br>Prof. Sigampa</td><td></td><td class="aplicada">Electrónica Aplicada I<br>Aula 512 (3R2)<br>Prof. Rivas</td><td class="seguridad">Seguridad e Higiene<br>Aula 604 (4R2)</td></tr>
+    <tr><td>18:15–19:55</td><td></td><td class="dispo">Dispositivos Electrónicos<br>Lab Anexo<br>Prof. Sigampa</td><td class="circuitos">Teoría de los Circuitos I<br>Aula 707 (3R3)<br>Prof. Peluca</td><td class="aplicada">Electrónica Aplicada I<br>Aula 209<br>Prof. Rivas</td><td class="seguridad">Seguridad e Higiene<br>Aula 604 (4R2)</td></tr>
     <tr><td>19:55–20:40</td><td></td><td class="circuitos">Teoría de los Circuitos I<br>Aula 707 (3R3)<br>Prof. Peluca</td><td></td><td></td><td class="dispo">Dispositivos Electrónicos<br>Aula 209<br>Prof. Guanuco</td></tr>
     <tr><td>20:40–21:25</td><td></td><td class="circuitos">Teoría de los Circuitos I<br>Aula 707 (3R3)<br>Prof. Peluca</td><td class="aplicada">Electrónica Aplicada I<br>Lab<br>Prof. Gilberto</td><td></td><td class="dispo">Dispositivos Electrónicos<br>Aula 209<br>Prof. Guanuco</td></tr>
     <tr><td>21:25–23:05</td><td></td><td></td><td class="aplicada">Electrónica Aplicada I<br>Lab<br>Prof. Gilberto</td><td></td><td class="dispo">Dispositivos Electrónicos<br>Aula 209<br>Prof. Guanuco</td></tr>


### PR DESCRIPTION
## Summary
- add missing Teoría de los Circuitos slot on Wednesday evenings
- correct classroom for Electrónica Aplicada I on Thursdays

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68547329a3f083218dd3e78aa87e8d9f